### PR TITLE
Adding test method to check sorted block orders by name

### DIFF
--- a/Famix-Simple-Diff/FMProperty.extension.st
+++ b/Famix-Simple-Diff/FMProperty.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : 'FMProperty' }
-
-{ #category : '*Famix-Simple-Diff' }
-FMProperty >> read: anEntity [
-
-	"For reflective purposes. If we use the slot reflectively, honor the defaultValue.
-	Are we using slots in the right way?"
-	^ (super read: anEntity) ifNil: [ self defaultValue ]
-]

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -99,6 +99,9 @@ FamixSimpleDiff >> computePathOfEntity: anEntity [
 	"We only work for single parent entities... And we hope this is the case always.
 	If not, talk to Guille, he has a point.
 	Read about lexical definition"
+	
+	"we create a special path for the case of primitives type"
+	anEntity isPrimitiveType ifTrue: [ ^ { #primitive . anEntity name } ].
 
 	self assert: anEntity containers asSet size <= 1.
 	
@@ -140,6 +143,13 @@ FamixSimpleDiff >> entityAtPath: indexPath fromEntity: entity [
 FamixSimpleDiff >> entityAtPath: indexPath inModel: model [
 
 	| rootEntity |
+	
+	"we detect the case of primitives types -> begin by '#primitive'"
+	"return the correct primitive"
+	indexPath  first = #primitive ifTrue: [
+		^ model  allPrimitiveTypes detect: [ :current | current name = indexPath second ]
+	].
+	
 	rootEntity := (self entityRoots: model) at: indexPath first.
 	^ self entityAtPath: indexPath allButFirst fromEntity: rootEntity
 ]

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -2,9 +2,9 @@ Class {
 	#name : 'FamixSimpleDiffTest',
 	#superclass : 'TestCase',
 	#instVars : [
-		'modelResources',
 		'mainModel1',
-		'mainModel2'
+		'mainModel2',
+		'libraryModel'
 	],
 	#category : 'Famix-Simple-Diff',
 	#package : 'Famix-Simple-Diff'
@@ -18,7 +18,8 @@ FamixSimpleDiffTest >> setUp [
 	self timeLimit: 15 seconds.
 	"Put here a common initialization logic for tests"
 	mainModel1 := TestJavaModelBuilder loadMainModel.
-	mainModel2 := TestJavaModelBuilder loadMainModel 
+	mainModel2 := TestJavaModelBuilder loadMainModel.
+	libraryModel := TestJavaModelBuilder loadLibraryModel 
 ]
 
 { #category : 'tests' }
@@ -150,6 +151,14 @@ FamixSimpleDiffTest >> testMethodsWithDifferentNamesAreNotEqual [
 	entity2 name: 'NewName'. 
 	
 	self assert: (sd compareEntity: entity1 to: entity2) equals: false
+]
+
+{ #category : 'tests' }
+FamixSimpleDiffTest >> testNotEqualModelsAreNotEqual [
+
+	| sd |
+	sd := FamixSimpleDiff new.
+	self deny: (sd compareModel: mainModel1 to: libraryModel)
 ]
 
 { #category : 'tests' }

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -14,6 +14,8 @@ Class {
 FamixSimpleDiffTest >> setUp [
 	super setUp.
 
+	"fix here to limit window's performances problems"
+	self timeLimit: 15 seconds.
 	"Put here a common initialization logic for tests"
 	mainModel1 := TestJavaModelBuilder loadMainModel.
 	mainModel2 := TestJavaModelBuilder loadMainModel 

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -78,6 +78,7 @@ FamixSimpleDiffTest >> testCorrespondingMethodsAreEqual [
 
 	| sd entity1 entity2 path |
 	sd := FamixSimpleDiff new.
+	
 	entity1 := mainModel1 entityNamed: 'some.thing.whatever.MainClass.getIntAttribute()'.
 	path := sd pathOfEntity: entity1.
 	entity2 := sd entityAtPath: path inModel: mainModel2.
@@ -95,6 +96,19 @@ FamixSimpleDiffTest >> testCorrespondingMethodsInSameModelIsSameEntity [
 	entity2 := sd entityAtPath: path inModel: mainModel1.
 	
 	self assert: entity1 == entity2
+]
+
+{ #category : 'tests' }
+FamixSimpleDiffTest >> testCorrespondingPrimitiveTypesAreEqual [
+
+	| sd entity1 entity2 path |
+	sd := FamixSimpleDiff new.
+
+	entity1 := (mainModel1 entityNamed: 'some.thing.whatever.MainClass.getIntAttribute()') declaredType.
+	path := sd pathOfEntity: entity1.
+	entity2 := sd entityAtPath: path inModel: mainModel2.
+	
+	self assert: (sd compareEntity: entity1 to: entity2)
 ]
 
 { #category : 'tests' }

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -191,3 +191,18 @@ FamixSimpleDiffTest >> testSameModelsAreEqual [
 	
 	self assert: (sd compareModel: mainModel1 to: mainModel1)
 ]
+
+{ #category : 'tests' }
+FamixSimpleDiffTest >> testSortBlockOrdersByName [
+
+	| sd block entity1 entity2 |
+	sd := FamixSimpleDiff new.
+	
+	block := sd sortBlock.
+	
+	entity1 := mainModel1 entityNamed: 'some.thing.whatever.MainClass'.
+	entity2 := mainModel1 entityNamed: 'some.thing.whatever.MainClass.getIntAttribute()'.
+	
+	self assert: (block value: entity2 value: entity1).
+	self deny: (block value: entity1 value: entity2)
+]


### PR DESCRIPTION
Mutation testing mutant -> [ :a :b |a mooseName > b mooseName] changed by [ :a :b |a mooseName < b mooseName]
This method is now fully covered.