### PR TITLE
Refactoring compareRelation:From:To:

### DIFF
--- a/Famix-Simple-Diff/FamixDiff.class.st
+++ b/Famix-Simple-Diff/FamixDiff.class.st
@@ -78,7 +78,7 @@ FamixDiff >> printOn: aStream [
 	"Will build a Stream like: FamixDiff(Addition -> Expected: ' ' | Actual: 'private int something' | On Class1)"
 	 
 	super printOn: aStream.
-	aStream nextPutAll: ' Famix Difference ('.
+	aStream nextPutAll: '('.
 	aStream print: changeType.
 	
 	aStream 

--- a/Famix-Simple-Diff/FamixDiff.class.st
+++ b/Famix-Simple-Diff/FamixDiff.class.st
@@ -11,6 +11,18 @@ Class {
 	#package : 'Famix-Simple-Diff'
 }
 
+{ #category : 'instance creation' }
+FamixDiff class >> entity: anEntity changeType: aSymbol expectedValue: val1 actualValue: val2 [
+
+	| difference |
+	difference := FamixDiff new.
+	difference entity: anEntity.
+	difference changeType: aSymbol.
+	difference expectedValue: val1.
+	difference actualValue: val2.
+	^ difference
+]
+
 { #category : 'accessing' }
 FamixDiff >> actualValue [
 

--- a/Famix-Simple-Diff/FamixDiff.class.st
+++ b/Famix-Simple-Diff/FamixDiff.class.st
@@ -70,3 +70,24 @@ FamixDiff >> expectedValue: anObject [
 
 	expectedValue := anObject
 ]
+
+{ #category : 'printing' }
+FamixDiff >> printOn: aStream [
+	"Redifine the display of the FamixDiff class"
+
+	"Will build a Stream like: FamixDiff(Addition -> Expected: ' ' | Actual: 'private int something' | On Class1)"
+	 
+	super printOn: aStream.
+	aStream nextPutAll: ' Famix Difference ('.
+	aStream print: changeType.
+	
+	aStream 
+		nextPutAll: ' -> Expected: '; 
+		print: expectedValue;
+		nextPutAll: ' | Actual: ';
+		print: actualValue.
+	
+	aStream nextPutAll: ' | On: '.
+	aStream print: entity.
+	aStream nextPutAll: ')'.
+]

--- a/Famix-Simple-Diff/FamixDiff.class.st
+++ b/Famix-Simple-Diff/FamixDiff.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : 'FamixDiff',
+	#superclass : 'Object',
+	#instVars : [
+		'entity',
+		'changeType',
+		'expectedValue',
+		'actualValue'
+	],
+	#category : 'Famix-Simple-Diff',
+	#package : 'Famix-Simple-Diff'
+}
+
+{ #category : 'accessing' }
+FamixDiff >> actualValue [
+
+	^ actualValue
+]
+
+{ #category : 'accessing' }
+FamixDiff >> actualValue: anObject [
+
+	actualValue := anObject
+]
+
+{ #category : 'accessing' }
+FamixDiff >> changeType [
+
+	^ changeType
+]
+
+{ #category : 'accessing' }
+FamixDiff >> changeType: anObject [
+
+	changeType := anObject
+]
+
+{ #category : 'accessing' }
+FamixDiff >> entity [
+
+	^ entity
+]
+
+{ #category : 'accessing' }
+FamixDiff >> entity: anObject [
+
+	entity := anObject
+]
+
+{ #category : 'accessing' }
+FamixDiff >> expectedValue [
+
+	^ expectedValue
+]
+
+{ #category : 'accessing' }
+FamixDiff >> expectedValue: anObject [
+
+	expectedValue := anObject
+]

--- a/Famix-Simple-Diff/FamixDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixDiffTest.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : 'FamixDiffTest',
+	#superclass : 'TestCase',
+	#category : 'Famix-Simple-Diff',
+	#package : 'Famix-Simple-Diff'
+}
+
+{ #category : 'tests' }
+FamixDiffTest >> testInstanceCreation [
+	| difference expectedValue actualValue |
+	
+	"testing a code modification"
+	expectedValue := 'private int money;'.
+	actualValue := 'private int age;'.
+	
+	difference := FamixDiff 
+						entity: 'testEntity' 
+						changeType: #entityModification
+						expectedValue: expectedValue 
+						actualValue: actualValue.
+						
+	"checking instance creation"
+	self assert: difference entity equals: 'testEntity'.
+	self assert: difference changeType equals: #entityModification.
+	self assert: difference expectedValue equals: expectedValue.
+	self assert: difference actualValue equals: actualValue.
+]

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -55,14 +55,7 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 	
 	"we compare the type of the entities. If we have not the same type, we add the difference in the list"
 	aFamixEntity class = otherFamixEntity class ifFalse: [ 
-		diff := (
-			FamixDiff 
-			entity: otherFamixEntity
-			changeType: #entityChanged
-			expectedValue: aFamixEntity class name 
-			actualValue: otherFamixEntity class name
-		).
-			
+		diff := (FamixDiff entity: otherFamixEntity changeType: #entityChanged expectedValue: aFamixEntity class name actualValue: otherFamixEntity class name).
 		self addDifference: diff.
 		^ self fail
 	].
@@ -76,13 +69,7 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 				prop1 := p read: aFamixEntity.
 				prop2 := p read: otherFamixEntity.
 				
-				diff := (
-					FamixDiff 
-					entity: otherFamixEntity
-					changeType: #propertyChanged
-					expectedValue: prop1 
-					actualValue: prop2 
-				).
+				diff := (FamixDiff entity: otherFamixEntity changeType: #propertyChanged expectedValue: prop1 actualValue: prop2).
 				self addDifference: diff.
 				isEquals := false 
 			] 
@@ -90,8 +77,7 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 
 	"Comparing relations (slots with famix values)"
 	"We exclude source anchors because they are not relevant to model comparison"
-	relations := aFamixEntity class allSlots select: [ :slot |
-		             slot isFMRelationSlot and: [ slot name ~= 'sourceAnchor' ] ].
+	relations := aFamixEntity class allSlots select: [ :slot | slot isFMRelationSlot and: [ slot name ~= 'sourceAnchor' ] ].
 	relations do: [ :r |
 		"self haltIf: [ r name = #methods ]."
 			(self compareRelation: r from: aFamixEntity to: otherFamixEntity)

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -223,6 +223,59 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 ]
 
 { #category : 'comparing' }
+FamixSimpleDiff >> compareToManyRelation: val1 actual: val2 target: anEntity [
+	| stream1 stream2 isEquals diff|
+	isEquals := true.
+	
+	stream1 := val1 readStream.
+	stream2 := val2 readStream.
+	
+	"looking the streams"
+	[ stream1 atEnd or: [ stream2 atEnd ] ] whileFalse: [ 
+		| elt1 elt2 name1 name2|
+		
+		"setup name"
+		elt1 := stream1 peek.
+		elt2 := stream2 peek.
+		
+		name1 := elt1 mooseName.
+		name2 := elt2 mooseName.
+		
+		name1 = name2 
+		"move forward both ptr if identicals"
+		ifTrue: [ 
+			stream1 next.
+			stream2 next.
+		]
+	
+		ifFalse: [ 
+			"deletion case"
+			name1 < name2 
+			ifTrue: [ 
+				diff := (FamixDiff entity: anEntity changeType: #entityRemoved expectedValue: elt1 actualValue: nil).
+				self addDifference: diff.
+				isEquals := false.
+				stream1 next. "ptr1++"
+			]
+		
+			"addition case"	
+			ifFalse: [ 
+				diff := (FamixDiff entity: anEntity changeType: #entityAdded expectedValue: nil actualValue: elt2).
+				self addDifference: diff.
+				isEquals := false.
+				stream2 next."ptr2++"
+			]
+		].
+	].
+
+	"cleaning end of pointers, checking if they have clean something"
+	(self clearRemainingDeletionOf: stream1 target: anEntity ) ifTrue: [ isEquals := false ].
+	(self clearRemainingAdditionOf: stream2 target: anEntity ) ifTrue: [ isEquals := false ].
+	
+	^ isEquals 
+]
+
+{ #category : 'comparing' }
 FamixSimpleDiff >> compareToOneRelation: val1 actual: val2 target: anEntity [
 	| areSame diff | 
 

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -222,6 +222,20 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 		^ isEquals.
 ]
 
+{ #category : 'comparing' }
+FamixSimpleDiff >> compareToOneRelation: val1 actual: val2 target: anEntity [
+	| areSame diff | 
+
+	"if we dont have the same relations, so it changed, we have to record it"
+	areSame := (self pathesForMaybeMultiRelation: val1) = (self pathesForMaybeMultiRelation: val2).
+	areSame ifFalse: [ 
+		diff := (FamixDiff entity: anEntity changeType: #relationChanged expectedValue: val1 actualValue: val2 ).
+		self addDifference: diff.
+	].
+
+	^ areSame "if they are not the same, so they are not equals"
+]
+
 { #category : 'path-computing' }
 FamixSimpleDiff >> computePathOfEntity: anEntity [
 	"We only work for single parent entities... And we hope this is the case always.

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -18,6 +18,21 @@ FamixSimpleDiff >> addDifference: aFamixDiff [
 ]
 
 { #category : 'accessing' }
+FamixSimpleDiff >> clearRemainingAdditionOf: aStream target: anEntity [
+	|  hasCleaned diff |
+	hasCleaned := false.
+	
+	[ aStream atEnd ] 
+	whileFalse: [
+				diff := (FamixDiff entity: anEntity changeType: #entityAdded expectedValue: nil actualValue: anEntity next).
+				self addDifference: diff.
+				hasCleaned := true. "we added something"
+	].
+
+	^ hasCleaned.
+]
+
+{ #category : 'accessing' }
 FamixSimpleDiff >> clearRemainingDeletionOf: aStream target: anEntity [
 	|  hasCleaned diff |
 	hasCleaned := false.

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -89,7 +89,7 @@ FamixSimpleDiff >> compareModel: aFamixJavaModel to: aFamixJavaModel2 [
 { #category : 'comparing' }
 FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: otherFamixEntity [
 
-	| val1 val2 sortBlock isEquals diff areSame|
+	| val1 val2 sortBlock isEquals diff|
 	isEquals := true.
 	
 	aFMRelationSlot isToOne
@@ -119,6 +119,7 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 
 	aFMRelationSlot isToOne
 		ifTrue: [
+			| areSame | 
 			"if we dont have the same relations, so it changed, we have to record it"
 			areSame := (self pathesForMaybeMultiRelation: val1) = (self pathesForMaybeMultiRelation: val2).
 			areSame ifFalse: [ 
@@ -133,19 +134,45 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 				isEquals := false.
 			]
 		]
-
-		ifFalse: [ "This is a toMany Relation! and the value should be a collection"
-				val1 size = val2 size ifFalse: [ ^ self fail ].
-				val1 := val1
+	
+		"This is a toMany Relation! and the value should be a collection"
+		ifFalse: [
+				
+				"if we have different sizes of val, here we have an addition or a deletion"
+				"val1 size = val2 size ifFalse: [ ^ self fail ]."
+				
+				| expectedBag actualBag|
+				expectedBag := val1
 					        flatCollect: [ :e | self pathesForMaybeMultiRelation: e ]
 					        as: Bag.
-				val2 := val2
+				actualBag := val2
 					        flatCollect: [ :e | self pathesForMaybeMultiRelation: e ]
 					        as: Bag.
 
-				val1 = val2
-					ifFalse: [ ^ self fail ]
-					ifTrue: [ ^ true ] ]
+				"compute additions and deletion between bags"
+				 expectedBag = actualBag ifFalse: [ 
+					isEquals := false.
+					
+					"deletion case, here in the model 1, but not in model 2"
+					val1 do:[ :expectedEntity |
+						| path allInBag|		
+						"check the path of the expected entity, if all the paths are not in the expectedBag, so we have a deletion"
+						path := self pathesForMaybeMultiRelation: expectedEntity.
+						allInBag := (path allSatisfy: [ :p | actualBag  includes: p]).
+						allInBag ifFalse: [ 
+							diff := (
+								FamixDiff 
+								entity: otherFamixEntity
+								changeType: #entityRemoved
+								expectedValue: expectedEntity 
+								actualValue: nil
+							).
+							self addDifference: diff.
+						].						
+					].
+					"addition case, not here in the model 1, but here in the model 2"
+				].
+		].
 ]
 
 { #category : 'path-computing' }

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -172,7 +172,7 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 					].
 
 					"addition case, not here in the model 1, but here in the model 2"
-					val1 do:[ :actualEntity |
+					val2 do:[ :actualEntity |
 						| path allInBag|		
 						"check the path of the actual entity, if all the paths are not in the actual, so we have a addition"
 						path := self pathesForMaybeMultiRelation: actualEntity .

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -170,7 +170,24 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 							self addDifference: diff.
 						].						
 					].
+
 					"addition case, not here in the model 1, but here in the model 2"
+					val1 do:[ :actualEntity |
+						| path allInBag|		
+						"check the path of the actual entity, if all the paths are not in the actual, so we have a addition"
+						path := self pathesForMaybeMultiRelation: actualEntity .
+						allInBag := (path allSatisfy: [ :p | expectedBag  includes: p]).
+						allInBag ifFalse: [ 
+							diff := (
+								FamixDiff
+								entity: otherFamixEntity
+								changeType: #entityAdded
+								expectedValue: nil
+								actualValue: actualEntity
+							).
+							self addDifference: diff.
+						].						
+					].
 				].
 		].
 ]

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -20,7 +20,7 @@ FamixSimpleDiff >> addDifference: aFamixDiff [
 FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 
 	| properties relations diff isEquals |
-	isEquals := false.
+	isEquals := true.
 	
 	"we compare the type of the entities. If we have not the same type, we add the difference in the list"
 	aFamixEntity class = otherFamixEntity class ifFalse: [ 

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -24,7 +24,7 @@ FamixSimpleDiff >> clearRemainingAdditionOf: aStream target: anEntity [
 	
 	[ aStream atEnd ] 
 	whileFalse: [
-				diff := (FamixDiff entity: anEntity changeType: #entityAdded expectedValue: nil actualValue: anEntity next).
+				diff := (FamixDiff entity: anEntity changeType: #entityAdded expectedValue: nil actualValue: aStream next).
 				self addDifference: diff.
 				hasCleaned := true. "we added something"
 	].

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -11,6 +11,11 @@ Class {
 	#package : 'Famix-Simple-Diff'
 }
 
+{ #category : 'accessing' }
+FamixSimpleDiff >> addDifference: aFamixDiff [
+	differences add: aFamixDiff
+]
+
 { #category : 'comparing' }
 FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -89,7 +89,9 @@ FamixSimpleDiff >> compareModel: aFamixJavaModel to: aFamixJavaModel2 [
 { #category : 'comparing' }
 FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: otherFamixEntity [
 
-	| val1 val2 sortBlock |
+	| val1 val2 sortBlock isEquals diff areSame|
+	isEquals := true.
+	
 	aFMRelationSlot isToOne
 		ifTrue: [
 				val1 := aFMRelationSlot read: aFamixEntity.
@@ -97,8 +99,7 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 		ifFalse: [
 				| rejectBlock |
 				val1 := (aFMRelationSlot read: aFamixEntity) asOrderedCollection.
-				val2 := (aFMRelationSlot read: otherFamixEntity)
-					        asOrderedCollection.
+				val2 := (aFMRelationSlot read: otherFamixEntity)asOrderedCollection.
 
 				sortBlock := val1
 					             ifEmpty: [ self sortBlock ]
@@ -117,7 +118,22 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 	val1 == val2 ifTrue: [ ^ true ].
 
 	aFMRelationSlot isToOne
-		ifTrue: [ ^ (self pathesForMaybeMultiRelation: val1) = (self pathesForMaybeMultiRelation: val2) ]
+		ifTrue: [
+			"if we dont have the same relations, so it changed, we have to record it"
+			areSame := (self pathesForMaybeMultiRelation: val1) = (self pathesForMaybeMultiRelation: val2).
+			areSame ifFalse: [ 
+				diff := (
+					FamixDiff 
+					entity: otherFamixEntity
+					changeType: #relationChanged
+					expectedValue: val1 
+					actualValue: val2 
+				).
+				self addDifference: diff.
+				isEquals := false.
+			]
+		]
+
 		ifFalse: [ "This is a toMany Relation! and the value should be a collection"
 				val1 size = val2 size ifFalse: [ ^ self fail ].
 				val1 := val1

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -125,13 +125,7 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 			"if we dont have the same relations, so it changed, we have to record it"
 			areSame := (self pathesForMaybeMultiRelation: val1) = (self pathesForMaybeMultiRelation: val2).
 			areSame ifFalse: [ 
-				diff := (
-					FamixDiff 
-					entity: otherFamixEntity
-					changeType: #relationChanged
-					expectedValue: val1 
-					actualValue: val2 
-				).
+				diff := (FamixDiff entity: otherFamixEntity changeType: #relationChanged expectedValue: val1 actualValue: val2 ).
 				self addDifference: diff.
 				isEquals := false.
 			]
@@ -139,58 +133,60 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 	
 		"This is a toMany Relation! and the value should be a collection"
 		ifFalse: [
+			| stream1 stream2|
+			stream1 := val1 readStream.
+			stream2 := val2 readStream.
+			
+			"looking the streams"
+			[ stream1 atEnd or: [ stream2 atEnd ] ] whileFalse: [ 
+				| elt1 elt2 name1 name2|
 				
-				"if we have different sizes of val, here we have an addition or a deletion"
-				"val1 size = val2 size ifFalse: [ ^ self fail ]."
+				"setup name"
+				elt1 := stream1 peek.
+				elt2 := stream2 peek.
 				
-				| expectedBag actualBag|
-				expectedBag := val1
-					        flatCollect: [ :e | self pathesForMaybeMultiRelation: e ]
-					        as: Bag.
-				actualBag := val2
-					        flatCollect: [ :e | self pathesForMaybeMultiRelation: e ]
-					        as: Bag.
-
-				"compute additions and deletion between bags"
-				 expectedBag = actualBag ifFalse: [ 
-					isEquals := false.
-					
-					"deletion case, here in the model 1, but not in model 2"
-					val1 do:[ :expectedEntity |
-						| path allInBag|		
-						"check the path of the expected entity, if all the paths are not in the expectedBag, so we have a deletion"
-						path := self pathesForMaybeMultiRelation: expectedEntity.
-						allInBag := (path allSatisfy: [ :p | actualBag  includes: p]).
-						allInBag ifFalse: [ 
-							diff := (
-								FamixDiff 
-								entity: otherFamixEntity
-								changeType: #entityRemoved
-								expectedValue: expectedEntity 
-								actualValue: nil
-							).
-							self addDifference: diff.
-						].						
-					].
-
-					"addition case, not here in the model 1, but here in the model 2"
-					val2 do:[ :actualEntity |
-						| path allInBag|		
-						"check the path of the actual entity, if all the paths are not in the actual, so we have a addition"
-						path := self pathesForMaybeMultiRelation: actualEntity .
-						allInBag := (path allSatisfy: [ :p | expectedBag  includes: p]).
-						allInBag ifFalse: [ 
-							diff := (
-								FamixDiff
-								entity: otherFamixEntity
-								changeType: #entityAdded
-								expectedValue: nil
-								actualValue: actualEntity
-							).
-							self addDifference: diff.
-						].						
-					].
+				name1 := elt1 mooseName.
+				name2 := elt2 mooseName.
+				
+				name1 = name2 
+				"move forward both ptr"
+				ifTrue: [ 
+					stream1 next.
+					stream2 next.
+				]
+			
+				ifFalse: [ 
+					"deletion case"
+					name1 < name2 
+					ifTrue: [ 
+						diff := (FamixDiff entity: otherFamixEntity changeType: #entityRemoved expectedValue: elt1 actualValue: nil).
+						self addDifference: diff.
+						isEquals := false.
+						stream1 next. "ptr1++"
+					]
+					"addition case"	
+					ifFalse: [ 
+						diff := (FamixDiff entity: otherFamixEntity changeType: #entityAdded expectedValue: nil actualValue: elt2).
+						self addDifference: diff.
+						isEquals := false.
+						stream2 next."ptr2++"
+					]
 				].
+			].
+
+			"clear all deletion of stream1"
+			[ stream1 atEnd ] whileFalse: [
+				diff := (FamixDiff entity: otherFamixEntity changeType: #entityRemoved expectedValue: stream1 next actualValue: nil).
+				self addDifference: diff.
+				isEquals := false.
+			].
+		
+			"clear all addition of stream2"
+			[ stream2 atEnd ] whileFalse: [
+				diff := (FamixDiff entity: otherFamixEntity changeType: #entityAdded expectedValue: nil actualValue: stream2 next).
+				self addDifference: diff.
+				isEquals := false.
+			].
 		].
 	
 		^ isEquals.

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -17,6 +17,21 @@ FamixSimpleDiff >> addDifference: aFamixDiff [
 	differences add: aFamixDiff
 ]
 
+{ #category : 'accessing' }
+FamixSimpleDiff >> clearRemainingDeletionOf: aStream target: anEntity [
+	|  hasCleaned diff |
+	hasCleaned := false.
+	
+	[ aStream atEnd ] 
+	whileFalse: [
+				diff := (FamixDiff entity: anEntity changeType: #entityRemoved expectedValue: aStream next actualValue: nil).
+				self addDifference: diff.
+				hasCleaned := true. "we deleted something"
+	].
+
+	^ hasCleaned.
+]
+
 { #category : 'comparing' }
 FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -120,9 +120,7 @@ FamixSimpleDiff >> compareModel: aFamixJavaModel to: aFamixJavaModel2 [
 
 { #category : 'comparing' }
 FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: otherFamixEntity [
-
-	| val1 val2 sortBlock isEquals diff|
-	isEquals := true.
+	| val1 val2 sortBlock|
 	
 	aFMRelationSlot isToOne
 		ifTrue: [
@@ -149,77 +147,11 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 	This guards for that..."
 	val1 == val2 ifTrue: [ ^ true ].
 
-	aFMRelationSlot isToOne
-		ifTrue: [
-			| areSame | 
-			"if we dont have the same relations, so it changed, we have to record it"
-			areSame := (self pathesForMaybeMultiRelation: val1) = (self pathesForMaybeMultiRelation: val2).
-			areSame ifFalse: [ 
-				diff := (FamixDiff entity: otherFamixEntity changeType: #relationChanged expectedValue: val1 actualValue: val2 ).
-				self addDifference: diff.
-				isEquals := false.
-			]
-		]
+	^ aFMRelationSlot isToOne
+		ifTrue: [ self compareToOneRelation: val1 actual: val2 target: otherFamixEntity ]
 	
 		"This is a toMany Relation! and the value should be a collection"
-		ifFalse: [
-			| stream1 stream2|
-			stream1 := val1 readStream.
-			stream2 := val2 readStream.
-			
-			"looking the streams"
-			[ stream1 atEnd or: [ stream2 atEnd ] ] whileFalse: [ 
-				| elt1 elt2 name1 name2|
-				
-				"setup name"
-				elt1 := stream1 peek.
-				elt2 := stream2 peek.
-				
-				name1 := elt1 mooseName.
-				name2 := elt2 mooseName.
-				
-				name1 = name2 
-				"move forward both ptr"
-				ifTrue: [ 
-					stream1 next.
-					stream2 next.
-				]
-			
-				ifFalse: [ 
-					"deletion case"
-					name1 < name2 
-					ifTrue: [ 
-						diff := (FamixDiff entity: otherFamixEntity changeType: #entityRemoved expectedValue: elt1 actualValue: nil).
-						self addDifference: diff.
-						isEquals := false.
-						stream1 next. "ptr1++"
-					]
-					"addition case"	
-					ifFalse: [ 
-						diff := (FamixDiff entity: otherFamixEntity changeType: #entityAdded expectedValue: nil actualValue: elt2).
-						self addDifference: diff.
-						isEquals := false.
-						stream2 next."ptr2++"
-					]
-				].
-			].
-
-			"clear all deletion of stream1"
-			[ stream1 atEnd ] whileFalse: [
-				diff := (FamixDiff entity: otherFamixEntity changeType: #entityRemoved expectedValue: stream1 next actualValue: nil).
-				self addDifference: diff.
-				isEquals := false.
-			].
-		
-			"clear all addition of stream2"
-			[ stream2 atEnd ] whileFalse: [
-				diff := (FamixDiff entity: otherFamixEntity changeType: #entityAdded expectedValue: nil actualValue: stream2 next).
-				self addDifference: diff.
-				isEquals := false.
-			].
-		].
-	
-		^ isEquals.
+		ifFalse: [ self compareToManyRelation: val1 actual: val2  target: otherFamixEntity ]
 ]
 
 { #category : 'comparing' }

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -19,15 +19,43 @@ FamixSimpleDiff >> addDifference: aFamixDiff [
 { #category : 'comparing' }
 FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 
-	| properties relations |
-	aFamixEntity class = otherFamixEntity class ifFalse: [ ^ self fail ].
+	| properties relations diff isEquals |
+	isEquals := false.
+	
+	"we compare the type of the entities. If we have not the same type, we add the difference in the list"
+	aFamixEntity class = otherFamixEntity class ifFalse: [ 
+		diff := (
+			FamixDiff 
+			entity: otherFamixEntity
+			changeType: #entityChanged
+			expectedValue: aFamixEntity class name 
+			actualValue: otherFamixEntity class name
+		).
+			
+		self addDifference: diff.
+		^ self fail
+	].
 
 	"Comparing properties (slots with non-famix values)"
 	properties := aFamixEntity class allSlots select: [ :slot |
 		              slot class = FMProperty ].
 	properties do: [ :p |
 			(p read: aFamixEntity) = (p read: otherFamixEntity) ifFalse: [
-				^ self fail ] ].
+				| prop1 prop2|
+				prop1 := p read: aFamixEntity.
+				prop2 := p read: otherFamixEntity.
+				
+				diff := (
+					FamixDiff 
+					entity: otherFamixEntity
+					changeType: #propertyChanged
+					expectedValue: prop1 
+					actualValue: prop2 
+				).
+				self addDifference: diff.
+				isEquals := false 
+			] 
+	].
 
 	"Comparing relations (slots with famix values)"
 	"We exclude source anchors because they are not relevant to model comparison"
@@ -35,8 +63,11 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 		             slot isFMRelationSlot and: [ slot name ~= 'sourceAnchor' ] ].
 	relations do: [ :r |
 			(self compareRelation: r from: aFamixEntity to: otherFamixEntity)
-				ifFalse: [ ^ self fail ] ].
+				ifFalse: [ isEquals := false ] ].
 
+	"we stop the execution here if models are differents"
+	isEquals ifFalse: [ ^ self fail ].
+	
 	"Every slot value is equal, the entities are identical"
 	^ true
 ]

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'roots',
 		'childrenCache',
-		'debug'
+		'debug',
+		'differences'
 	],
 	#category : 'Famix-Simple-Diff',
 	#package : 'Famix-Simple-Diff'
@@ -127,6 +128,11 @@ FamixSimpleDiff >> debugOn [
 	debug := true
 ]
 
+{ #category : 'accessing' }
+FamixSimpleDiff >> differences [
+	^ differences
+]
+
 { #category : 'path-computing' }
 FamixSimpleDiff >> entityAtPath: indexPath fromEntity: entity [
 
@@ -178,7 +184,8 @@ FamixSimpleDiff >> initialize [
 	
 	super initialize.
 	debug := false.
-	childrenCache := LRUCache new maximumWeight: 100
+	childrenCache := LRUCache new maximumWeight: 100.
+	differences := OrderedCollection new.
 ]
 
 { #category : 'path-computing' }

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -190,6 +190,8 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 					].
 				].
 		].
+	
+		^ isEquals.
 ]
 
 { #category : 'path-computing' }

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -13,6 +13,7 @@ Class {
 
 { #category : 'accessing' }
 FamixSimpleDiff >> addDifference: aFamixDiff [
+	"1halt."
 	differences add: aFamixDiff
 ]
 
@@ -62,6 +63,7 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 	relations := aFamixEntity class allSlots select: [ :slot |
 		             slot isFMRelationSlot and: [ slot name ~= 'sourceAnchor' ] ].
 	relations do: [ :r |
+		"self haltIf: [ r name = #methods ]."
 			(self compareRelation: r from: aFamixEntity to: otherFamixEntity)
 				ifFalse: [ isEquals := false ] ].
 

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -146,14 +146,17 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 	
 	"methods"
 	method1 := FamixJavaMethod new name: 'myMethod'.
+	method1 signature: 'myMethod()'.
 	method2 := FamixJavaMethod new name: 'myMethod'.
+	method2 signature: 'myMethod()'.
 	method3 := FamixJavaMethod new name: 'deletedMethod'.
+	method3 signature: 'deletedMethod()'.
 	class1 methods: { method3 . method1 }.
 	class2 methods: { method2 }.
 	
 	model1 add: class1.
 	model2 add: class2.
-	
+	"self halt."
 	self deny: (sd compareEntity: class1 to: class2).
 	self assert: sd differences size equals: 1.
 		

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -95,6 +95,27 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferen
 ]
 
 { #category : 'tests' }
+FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndNotSameMethods [
+	| sd class1 class2 method1 method2 method3 |
+	sd := FamixSimpleDiff new.
+	
+	"same classes"
+	class1 := FamixJavaClass new name: 'MyClass'.
+	class2 := FamixJavaClass new name: 'MyClass'.
+	
+	"same methods"
+	method1 := FamixJavaMethod new name: 'myMethod'.
+	method2 := FamixJavaMethod new name: 'myMethod'.
+	method3 := FamixJavaMethod new name: 'newMethod'.
+		
+	class1 methods: { method1 }.
+	class2 methods: { method2 . method3 }.
+	
+	self deny: (sd compareEntity: class1 to: class2).
+	self assert: sd differences size equals: 1.
+]
+
+{ #category : 'tests' }
 FamixSimpleDiffTest >> testCompareEntityToReturnsTrueAndEmptyDiffListWhenSameClasses [
 	| sd class1 class2 |
 	sd := FamixSimpleDiff new.
@@ -102,6 +123,26 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsTrueAndEmptyDiffListWhenSameCla
 	"same classes"
 	class1 := FamixJavaClass new name: 'MyClass'.
 	class2 := FamixJavaClass new name: 'MyClass'.
+	
+	self assert: (sd compareEntity: class1 to: class2).
+	self assert: sd differences isEmpty.
+]
+
+{ #category : 'tests' }
+FamixSimpleDiffTest >> testCompareEntityToReturnsTrueWhenSameClassesAndSameMethods [
+	| sd class1 class2 method1 method2 |
+	sd := FamixSimpleDiff new.
+	
+	"same classes"
+	class1 := FamixJavaClass new name: 'MyClass'.
+	class2 := FamixJavaClass new name: 'MyClass'.
+	
+	"same methods"
+	method1 := FamixJavaMethod new name: 'myMethod'.
+	method2 := FamixJavaMethod new name: 'myMethod'.
+		
+	class1 methods: { method1 }.
+	class2 methods: { method2 }.
 	
 	self assert: (sd compareEntity: class1 to: class2).
 	self assert: sd differences isEmpty.

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -146,6 +146,9 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsTrueWhenSameClassesAndSameMetho
 	
 	self assert: (sd compareEntity: class1 to: class2).
 	self assert: sd differences isEmpty.
+	
+
+"TODO -> FIX"
 ]
 
 { #category : 'tests' }

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -96,7 +96,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferen
 
 { #category : 'tests' }
 FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodIsAdded [
-	| sd class1 class2 method1 method2 method3 model1 model2 |
+	| sd class1 class2 method1 method2 method3 model1 model2 diff |
 	sd := FamixSimpleDiff new.
 
 	"we need to create a model to contain our entities"
@@ -120,6 +120,45 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 	
 	self deny: (sd compareEntity: class1 to: class2).
 	self assert: sd differences size equals: 1.
+		
+	diff := sd differences first.
+	
+	self assert: diff changeType equals: #entityAdded.
+	self assert: diff expectedValue equals: nil.
+	self assert: diff actualValue name equals: 'newMethod'.
+]
+
+{ #category : 'tests' }
+FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodIsDeleted [
+	| sd class1 class2 method1 method2 method3 model1 model2 diff |
+	sd := FamixSimpleDiff new.
+
+	"we need to create a model to contain our entities"
+	model1 := FamixJavaModel new.
+	model2 := FamixJavaModel new.	
+	
+	"same classes"
+	class1 := FamixJavaClass new name: 'MyClass'.
+	class2 := FamixJavaClass new name: 'MyClass'.
+	
+	"methods"
+	method1 := FamixJavaMethod new name: 'myMethod'.
+	method2 := FamixJavaMethod new name: 'myMethod'.
+	method3 := FamixJavaMethod new name: 'deletedMethod'.
+	class1 methods: { method1 . method3 }.
+	class2 methods: { method2 }.
+	
+	model1 add: class1.
+	model2 add: class2.
+	
+	self deny: (sd compareEntity: class1 to: class2).
+	self assert: sd differences size equals: 1.
+		
+	diff := sd differences first.
+	
+	self assert: diff changeType equals: #entityRemoved.
+	self assert: diff expectedValue name equals: 'deletedMethod'.
+	self assert: diff actualValue equals: nil.
 ]
 
 { #category : 'tests' }

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -51,15 +51,35 @@ FamixSimpleDiffTest >> testClassesWithDifferentSuperclassesAreNotEqual [
 ]
 
 { #category : 'tests' }
+FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferentType [
+	| sd class method diff |
+	sd := FamixSimpleDiff new.
+	
+	"different classes"
+	class := FamixJavaClass new name: 'MyClass'.
+	method := FamixJavaMethod new name: 'MyMethod'.
+	
+	"checking the list of diff"
+	self deny: (sd compareEntity: class to: method).
+	self deny: sd differences isEmpty.
+	self assert: sd differences size equals: 1.
+	
+	diff := sd differences first.
+	
+	self assert: diff changeType equals: #entityChanged.
+	self assert: diff expectedValue equals: 'FamixJavaClass'.
+	self assert: diff actualValue equals: 'FamixJavaMethod'.
+	
+]
+
+{ #category : 'tests' }
 FamixSimpleDiffTest >> testCompareEntityToReturnsTrueAndEmptyDiffListWhenSameClasses [
 	| sd class1 class2 |
 	sd := FamixSimpleDiff new.
 	
 	"same classes"
-	class1 := FamixJavaClass new name: 'MyClass'; 
-	isStub: false.
-	class2 := FamixJavaClass new name: 'MyClass'; 
-	isStub: false.
+	class1 := FamixJavaClass new name: 'MyClass'.
+	class2 := FamixJavaClass new name: 'MyClass'.
 	
 	self assert: (sd compareEntity: class1 to: class2).
 	self assert: sd differences isEmpty.

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -109,11 +109,14 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 	
 	"same methods"
 	method1 := FamixJavaMethod new name: 'myMethod'.
+	method1 signature: 'myMethod()'.
 	method2 := FamixJavaMethod new name: 'myMethod'.
+	method2 signature: 'myMethod()'.
 	method3 := FamixJavaMethod new name: 'newMethod'.
+	method3 signature: 'newMethod()'.
 		
 	class1 methods: { method1 }.
-	class2 methods: { method3 . method2 }.
+	class2 methods: { method2 . method3 }.
 	
 	model1 add: class1.
 	model2 add: class2.

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -51,6 +51,28 @@ FamixSimpleDiffTest >> testClassesWithDifferentSuperclassesAreNotEqual [
 ]
 
 { #category : 'tests' }
+FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferentClasses [
+	| sd class1 class2 diff |
+	sd := FamixSimpleDiff new.
+	
+	"different classes"
+	class1 := FamixJavaClass new name: 'MyClass'.
+	class2 := FamixJavaClass new name: 'MyOtherClass'.
+	
+	"checking the list of diff"
+	self deny: (sd compareEntity: class1 to: class2).
+	self deny: sd differences isEmpty.
+	self assert: sd differences size equals: 1.
+	
+	diff := sd differences first.
+	
+	self assert: diff changeType equals: #entityChanged.
+	self assert: diff expectedValue equals: 'MyClass'.
+	self assert: diff actualValue equals: 'MyOtherClass'.
+	
+]
+
+{ #category : 'tests' }
 FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferentType [
 	| sd class method diff |
 	sd := FamixSimpleDiff new.

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -51,6 +51,21 @@ FamixSimpleDiffTest >> testClassesWithDifferentSuperclassesAreNotEqual [
 ]
 
 { #category : 'tests' }
+FamixSimpleDiffTest >> testCompareEntityToReturnsTrueAndEmptyDiffListWhenSameClasses [
+	| sd class1 class2 |
+	sd := FamixSimpleDiff new.
+	
+	"same classes"
+	class1 := FamixJavaClass new name: 'MyClass'; 
+	isStub: false.
+	class2 := FamixJavaClass new name: 'MyClass'; 
+	isStub: false.
+	
+	self assert: (sd compareEntity: class1 to: class2).
+	self assert: sd differences isEmpty.
+]
+
+{ #category : 'tests' }
 FamixSimpleDiffTest >> testCorrespondingClassesAreEqual [
 
 	| sd entity1 entity2 path |

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -66,7 +66,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferen
 	
 	diff := sd differences first.
 	
-	self assert: diff changeType equals: #entityChanged.
+	self assert: diff changeType equals: #propertyChanged.
 	self assert: diff expectedValue equals: 'MyClass'.
 	self assert: diff actualValue equals: 'MyOtherClass'.
 	

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -113,7 +113,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 	method3 := FamixJavaMethod new name: 'newMethod'.
 		
 	class1 methods: { method1 }.
-	class2 methods: { method2 . method3 }.
+	class2 methods: { method3 . method2 }.
 	
 	model1 add: class1.
 	model2 add: class2.
@@ -145,7 +145,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 	method1 := FamixJavaMethod new name: 'myMethod'.
 	method2 := FamixJavaMethod new name: 'myMethod'.
 	method3 := FamixJavaMethod new name: 'deletedMethod'.
-	class1 methods: { method1 . method3 }.
+	class1 methods: { method3 . method1 }.
 	class2 methods: { method2 }.
 	
 	model1 add: class1.

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -96,8 +96,12 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferen
 
 { #category : 'tests' }
 FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodIsAdded [
-	| sd class1 class2 method1 method2 method3 |
+	| sd class1 class2 method1 method2 method3 model1 model2 |
 	sd := FamixSimpleDiff new.
+
+	"we need to create a model to contain our entities"
+	model1 := FamixJavaModel new.
+	model2 := FamixJavaModel new.	
 	
 	"same classes"
 	class1 := FamixJavaClass new name: 'MyClass'.
@@ -110,6 +114,9 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 		
 	class1 methods: { method1 }.
 	class2 methods: { method2 . method3 }.
+	
+	model1 add: class1.
+	model2 add: class2.
 	
 	self deny: (sd compareEntity: class1 to: class2).
 	self assert: sd differences size equals: 1.
@@ -130,8 +137,12 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsTrueAndEmptyDiffListWhenSameCla
 
 { #category : 'tests' }
 FamixSimpleDiffTest >> testCompareEntityToReturnsTrueWhenSameClassesAndSameMethods [
-	| sd class1 class2 method1 method2 |
+	| sd class1 class2 method1 method2 model1 model2 |
 	sd := FamixSimpleDiff new.
+	
+	"we need to create a model to contain our entities"
+	model1 := FamixJavaModel new.
+	model2 := FamixJavaModel new.
 	
 	"same classes"
 	class1 := FamixJavaClass new name: 'MyClass'.
@@ -144,11 +155,11 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsTrueWhenSameClassesAndSameMetho
 	class1 methods: { method1 }.
 	class2 methods: { method2 }.
 	
+	model1 add: class1.
+	model2 add: class2.
+	
 	self assert: (sd compareEntity: class1 to: class2).
 	self assert: sd differences isEmpty.
-	
-
-"TODO -> FIX"
 ]
 
 { #category : 'tests' }

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -95,7 +95,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferen
 ]
 
 { #category : 'tests' }
-FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndNotSameMethods [
+FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodIsAdded [
 	| sd class1 class2 method1 method2 method3 |
 	sd := FamixSimpleDiff new.
 	


### PR DESCRIPTION
I refactored the method compareRelation:From:To: due to the length of this method.
I splited this method in 4 submethods:
- clearRemainingAdditionOf: target: -> a method that will clear the remaining additions of the pointer 2
- clearRemainingDeletionOf: target -> a method that will clear the remaining deletions of the pointer 1
- compareToOneRelation: actual: target: -> a method for the differences of a toOne relation 
- compareToManyRelation: actual: target: -> a method for the differences of a toMany relation 
 
