### PR TITLE
Deleting nil

### DIFF
--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -24,7 +24,7 @@ FamixSimpleDiff >> clearRemainingAdditionOf: aStream target: anEntity [
 	
 	[ aStream atEnd ] 
 	whileFalse: [
-				diff := FamixDiff createEntityAdded: anEntity actualValue: aStream next. 
+				diff := FamixSimpleDifference createEntityAdded: anEntity actualValue: aStream next. 
 				self addDifference: diff.
 				hasCleaned := true. "we added something"
 	].
@@ -39,7 +39,7 @@ FamixSimpleDiff >> clearRemainingDeletionOf: aStream target: anEntity [
 	
 	[ aStream atEnd ] 
 	whileFalse: [
-				diff := FamixDiff createEntityRemoved: anEntity expectedValue: aStream next.
+				diff := FamixSimpleDifference createEntityRemoved: anEntity expectedValue: aStream next.
 				self addDifference: diff.
 				hasCleaned := true. "we deleted something"
 	].
@@ -55,7 +55,7 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 	
 	"we compare the type of the entities. If we have not the same type, we add the difference in the list"
 	aFamixEntity class = otherFamixEntity class ifFalse: [ 
-		diff := FamixDiff createEntityChanged: otherFamixEntity expectedValue: aFamixEntity class name actualValue: otherFamixEntity class name. 
+		diff := FamixSimpleDifference createEntityChanged: otherFamixEntity expectedValue: aFamixEntity class name actualValue: otherFamixEntity class name. 
 		self addDifference: diff.
 		^ self fail
 	].
@@ -69,7 +69,7 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 				prop1 := p read: aFamixEntity.
 				prop2 := p read: otherFamixEntity.
 				
-				diff := FamixDiff createPropertyChanged: otherFamixEntity expectedValue: prop1 actualValue: prop2.
+				diff := FamixSimpleDifference createPropertyChanged: otherFamixEntity expectedValue: prop1 actualValue: prop2.
 				self addDifference: diff.
 				isEquals := false 
 			] 
@@ -177,7 +177,7 @@ FamixSimpleDiff >> compareToManyRelation: val1 actual: val2 target: anEntity [
 			"deletion case"
 			name1 < name2 
 			ifTrue: [ 
-				diff := FamixDiff createEntityRemoved: anEntity expectedValue: elt1.
+				diff := FamixSimpleDifference createEntityRemoved: anEntity expectedValue: elt1.
 				self addDifference: diff.
 				isEquals := false.
 				stream1 next. "ptr1++"
@@ -185,7 +185,7 @@ FamixSimpleDiff >> compareToManyRelation: val1 actual: val2 target: anEntity [
 		
 			"addition case"	
 			ifFalse: [
-				diff := FamixDiff createEntityAdded: anEntity actualValue: elt2.  
+				diff := FamixSimpleDifference createEntityAdded: anEntity actualValue: elt2.  
 				self addDifference: diff.
 				isEquals := false.
 				stream2 next."ptr2++"
@@ -207,7 +207,7 @@ FamixSimpleDiff >> compareToOneRelation: val1 actual: val2 target: anEntity [
 	"if we dont have the same relations, so it changed, we have to record it"
 	areSame := (self pathesForMaybeMultiRelation: val1) = (self pathesForMaybeMultiRelation: val2).
 	areSame ifFalse: [ 
-		diff := FamixDiff createRelationChanged: anEntity expectedValue: val1 actualValue: val2.
+		diff := FamixSimpleDifference createRelationChanged: anEntity expectedValue: val1 actualValue: val2.
 		self addDifference: diff.
 	].
 

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -129,11 +129,11 @@ FamixSimpleDiffTest >> testClearRemainingSuppressionWhenMultipleMethodHaveToBeCl
 	
 	self assert: diff first changeType equals: FamixSimpleDifference entityRemoved.
 	self assert: diff first expectedValue name equals: 'methodB'.
-	self assert: diff first actualValue equals: nil.
+	self assert: diff first actualValue class equals: FamixSimpleDifferenceNullValue.
 	
 	self assert: diff second changeType equals: FamixSimpleDifference entityRemoved.
 	self assert: diff second expectedValue name equals: 'methodC'.
-	self assert: diff second actualValue equals: nil.
+	self assert: diff second actualValue class equals: FamixSimpleDifferenceNullValue.
 ]
 
 { #category : 'tests' }
@@ -210,7 +210,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenAMethodIsAddedBeforeEx
 	diff := sd differences.
 	
 	self assert: diff first changeType equals: FamixSimpleDifference entityAdded.
-	self assert: diff first expectedValue equals: nil.
+	self assert: diff first expectedValue class equals: FamixSimpleDifferenceNullValue.
 	self assert: diff first actualValue equals: methodA.
 ]
 
@@ -247,7 +247,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 	diff := sd differences first.
 	
 	self assert: diff changeType equals: FamixSimpleDifference entityAdded.
-	self assert: diff expectedValue equals: nil.
+	self assert: diff expectedValue class equals: FamixSimpleDifferenceNullValue.
 	self assert: diff actualValue name equals: 'newMethod'.
 ]
 
@@ -284,7 +284,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 	
 	self assert: diff changeType equals: FamixSimpleDifference entityRemoved.
 	self assert: diff expectedValue name equals: 'deletedMethod'.
-	self assert: diff actualValue equals: nil.
+	self assert: diff actualValue class equals: FamixSimpleDifferenceNullValue.
 ]
 
 { #category : 'tests' }

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -84,11 +84,11 @@ FamixSimpleDiffTest >> testClearRemainingAdditionWhenMultipleMethodHaveToBeClean
 		
 	diff := sd differences.
 	
-	self assert: diff first changeType equals: FamixDiff entityAdded.
+	self assert: diff first changeType equals: FamixSimpleDifference entityAdded.
 	self assert: diff first expectedValue equals: nil.
 	self assert: diff first actualValue name equals: 'methodB'.
 	
-	self assert: diff second changeType equals: FamixDiff entityAdded.
+	self assert: diff second changeType equals: FamixSimpleDifference entityAdded.
 	self assert: diff second expectedValue equals: nil.
 	self assert: diff second actualValue name equals: 'methodC'.
 ]
@@ -127,11 +127,11 @@ FamixSimpleDiffTest >> testClearRemainingSuppressionWhenMultipleMethodHaveToBeCl
 		
 	diff := sd differences.
 	
-	self assert: diff first changeType equals: FamixDiff entityRemoved.
+	self assert: diff first changeType equals: FamixSimpleDifference entityRemoved.
 	self assert: diff first expectedValue name equals: 'methodB'.
 	self assert: diff first actualValue equals: nil.
 	
-	self assert: diff second changeType equals: FamixDiff entityRemoved.
+	self assert: diff second changeType equals: FamixSimpleDifference entityRemoved.
 	self assert: diff second expectedValue name equals: 'methodC'.
 	self assert: diff second actualValue equals: nil.
 ]
@@ -152,7 +152,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferen
 	
 	diff := sd differences first.
 	
-	self assert: diff changeType equals: FamixDiff propertyChanged. 
+	self assert: diff changeType equals: FamixSimpleDifference propertyChanged. 
 	self assert: diff expectedValue equals: 'MyClass'.
 	self assert: diff actualValue equals: 'MyOtherClass'.
 	
@@ -174,7 +174,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseAndRecordsDiffWhenDifferen
 	
 	diff := sd differences first.
 	
-	self assert: diff changeType equals: FamixDiff entityChanged.
+	self assert: diff changeType equals: FamixSimpleDifference entityChanged.
 	self assert: diff expectedValue equals: 'FamixJavaClass'.
 	self assert: diff actualValue equals: 'FamixJavaMethod'.
 	
@@ -209,7 +209,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenAMethodIsAddedBeforeEx
 		
 	diff := sd differences.
 	
-	self assert: diff first changeType equals: FamixDiff entityAdded.
+	self assert: diff first changeType equals: FamixSimpleDifference entityAdded.
 	self assert: diff first expectedValue equals: nil.
 	self assert: diff first actualValue equals: methodA.
 ]
@@ -246,7 +246,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 		
 	diff := sd differences first.
 	
-	self assert: diff changeType equals: FamixDiff entityAdded.
+	self assert: diff changeType equals: FamixSimpleDifference entityAdded.
 	self assert: diff expectedValue equals: nil.
 	self assert: diff actualValue name equals: 'newMethod'.
 ]
@@ -282,7 +282,7 @@ FamixSimpleDiffTest >> testCompareEntityToReturnsFalseWhenSameClassesAndAMethodI
 		
 	diff := sd differences first.
 	
-	self assert: diff changeType equals: FamixDiff entityRemoved.
+	self assert: diff changeType equals: FamixSimpleDifference entityRemoved.
 	self assert: diff expectedValue name equals: 'deletedMethod'.
 	self assert: diff actualValue equals: nil.
 ]
@@ -418,7 +418,7 @@ FamixSimpleDiffTest >> testDifferenceDetectedWhenToOneRelationChanged [
 
     diff := sd differences.
 
-    self assert: diff first changeType equals:  FamixDiff relationChanged.
+    self assert: diff first changeType equals:  FamixSimpleDifference relationChanged.
     self assert: diff first expectedValue equals: class1.
     self assert: diff first actualValue equals: class2
 ]

--- a/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiffTest.class.st
@@ -85,11 +85,11 @@ FamixSimpleDiffTest >> testClearRemainingAdditionWhenMultipleMethodHaveToBeClean
 	diff := sd differences.
 	
 	self assert: diff first changeType equals: FamixSimpleDifference entityAdded.
-	self assert: diff first expectedValue equals: nil.
+	self assert: diff first expectedValue class equals: FamixSimpleDifferenceNullValue.
 	self assert: diff first actualValue name equals: 'methodB'.
 	
 	self assert: diff second changeType equals: FamixSimpleDifference entityAdded.
-	self assert: diff second expectedValue equals: nil.
+	self assert: diff first expectedValue class equals: FamixSimpleDifferenceNullValue.
 	self assert: diff second actualValue name equals: 'methodC'.
 ]
 

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -16,7 +16,7 @@ FamixSimpleDifference class >> createEntityAdded: anEntity actualValue: actualVa
 	^ self 
 		entity: anEntity 
 		changeType: self entityAdded
-		expectedValue: nil 
+		expectedValue: FamixSimpleDifferenceNullValue new
 		actualValue: actualValue 
 ]
 
@@ -35,7 +35,7 @@ FamixSimpleDifference class >> createEntityRemoved: anEntity expectedValue: expe
 		entity: anEntity 
 		changeType: self entityRemoved 
 		expectedValue: expectedValue 
-		actualValue: nil
+		actualValue: FamixSimpleDifferenceNullValue new
 ]
 
 { #category : 'instance creation' }

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'FamixDiff',
+	#name : 'FamixSimpleDifference',
 	#superclass : 'Object',
 	#instVars : [
 		'entity',
@@ -12,7 +12,7 @@ Class {
 }
 
 { #category : 'instance creation' }
-FamixDiff class >> createEntityAdded: anEntity actualValue: actualValue [ 
+FamixSimpleDifference class >> createEntityAdded: anEntity actualValue: actualValue [ 
 	^ self 
 		entity: anEntity 
 		changeType: self entityAdded
@@ -21,7 +21,7 @@ FamixDiff class >> createEntityAdded: anEntity actualValue: actualValue [
 ]
 
 { #category : 'instance creation' }
-FamixDiff class >> createEntityChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
+FamixSimpleDifference class >> createEntityChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
 	^ self 
 		entity: anEntity 
 		changeType: self entityChanged 
@@ -30,7 +30,7 @@ FamixDiff class >> createEntityChanged: anEntity expectedValue: expectedValue ac
 ]
 
 { #category : 'instance creation' }
-FamixDiff class >> createEntityRemoved: anEntity expectedValue: expectedValue [ 
+FamixSimpleDifference class >> createEntityRemoved: anEntity expectedValue: expectedValue [ 
 	^ self 
 		entity: anEntity 
 		changeType: self entityRemoved 
@@ -39,7 +39,7 @@ FamixDiff class >> createEntityRemoved: anEntity expectedValue: expectedValue [
 ]
 
 { #category : 'instance creation' }
-FamixDiff class >> createPropertyChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
+FamixSimpleDifference class >> createPropertyChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
 	^ self 
 		entity: anEntity 
 		changeType: self propertyChanged 
@@ -48,7 +48,7 @@ FamixDiff class >> createPropertyChanged: anEntity expectedValue: expectedValue 
 ]
 
 { #category : 'instance creation' }
-FamixDiff class >> createRelationChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
+FamixSimpleDifference class >> createRelationChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
 	^ self 
 		entity: anEntity 
 		changeType: self relationChanged 
@@ -57,10 +57,10 @@ FamixDiff class >> createRelationChanged: anEntity expectedValue: expectedValue 
 ]
 
 { #category : 'instance creation' }
-FamixDiff class >> entity: anEntity changeType: aSymbol expectedValue: val1 actualValue: val2 [
+FamixSimpleDifference class >> entity: anEntity changeType: aSymbol expectedValue: val1 actualValue: val2 [
 
 	| difference |
-	difference := FamixDiff new.
+	difference := FamixSimpleDifference new.
 	difference entity: anEntity.
 	difference changeType: aSymbol.
 	difference expectedValue: val1.
@@ -69,80 +69,80 @@ FamixDiff class >> entity: anEntity changeType: aSymbol expectedValue: val1 actu
 ]
 
 { #category : 'constants' }
-FamixDiff class >> entityAdded [
+FamixSimpleDifference class >> entityAdded [
 	^ #entityAdded
 ]
 
 { #category : 'constants' }
-FamixDiff class >> entityChanged [
+FamixSimpleDifference class >> entityChanged [
 	^ #entityChanged 
 ]
 
 { #category : 'constants' }
-FamixDiff class >> entityRemoved [
+FamixSimpleDifference class >> entityRemoved [
 	^ #entityRemoved
 ]
 
 { #category : 'constants' }
-FamixDiff class >> propertyChanged [ 
+FamixSimpleDifference class >> propertyChanged [ 
 	^ #propertyChanged 
 ]
 
 { #category : 'constants' }
-FamixDiff class >> relationChanged [ 
+FamixSimpleDifference class >> relationChanged [ 
 	^ #relationChanged 
 ]
 
 { #category : 'accessing' }
-FamixDiff >> actualValue [
+FamixSimpleDifference >> actualValue [
 
 	^ actualValue
 ]
 
 { #category : 'accessing' }
-FamixDiff >> actualValue: anObject [
+FamixSimpleDifference >> actualValue: anObject [
 
 	actualValue := anObject
 ]
 
 { #category : 'accessing' }
-FamixDiff >> changeType [
+FamixSimpleDifference >> changeType [
 
 	^ changeType
 ]
 
 { #category : 'accessing' }
-FamixDiff >> changeType: anObject [
+FamixSimpleDifference >> changeType: anObject [
 
 	changeType := anObject
 ]
 
 { #category : 'accessing' }
-FamixDiff >> entity [
+FamixSimpleDifference >> entity [
 
 	^ entity
 ]
 
 { #category : 'accessing' }
-FamixDiff >> entity: anObject [
+FamixSimpleDifference >> entity: anObject [
 
 	entity := anObject
 ]
 
 { #category : 'accessing' }
-FamixDiff >> expectedValue [
+FamixSimpleDifference >> expectedValue [
 
 	^ expectedValue
 ]
 
 { #category : 'accessing' }
-FamixDiff >> expectedValue: anObject [
+FamixSimpleDifference >> expectedValue: anObject [
 
 	expectedValue := anObject
 ]
 
 { #category : 'printing' }
-FamixDiff >> printOn: aStream [
+FamixSimpleDifference >> printOn: aStream [
 	"Redifine the display of the FamixDiff class"
 
 	"Will build a Stream like: FamixDiff(Addition -> Expected: ' ' | Actual: 'private int something' | On Class1)"

--- a/Famix-Simple-Diff/FamixSimpleDifferenceNullValue.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifferenceNullValue.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : 'FamixSimpleDifferenceNullValue',
+	#superclass : 'Object',
+	#category : 'Famix-Simple-Diff',
+	#package : 'Famix-Simple-Diff'
+}
+
+{ #category : 'accessing' }
+FamixSimpleDifferenceNullValue >> mooseName [
+	^ 'Nothing'
+]
+
+{ #category : 'accessing' }
+FamixSimpleDifferenceNullValue >> name [
+	^ 'Nothing'
+]
+
+{ #category : 'printing' }
+FamixSimpleDifferenceNullValue >> printOn: aStream [
+	aStream nextPutAll: 'Nothing'
+]

--- a/Famix-Simple-Diff/FamixSimpleDifferenceTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifferenceTest.class.st
@@ -15,13 +15,13 @@ FamixSimpleDifferenceTest >> testInstanceCreation [
 	
 	difference := FamixSimpleDifference 
 						entity: 'testEntity' 
-						changeType: #entityModification
+						changeType: FamixSimpleDifference entityChanged
 						expectedValue: expectedValue 
 						actualValue: actualValue.
 						
 	"checking instance creation"
 	self assert: difference entity equals: 'testEntity'.
-	self assert: difference changeType equals: #entityModification.
+	self assert: difference changeType equals: FamixSimpleDifference entityChanged.
 	self assert: difference expectedValue equals: expectedValue.
 	self assert: difference actualValue equals: actualValue.
 ]

--- a/Famix-Simple-Diff/FamixSimpleDifferenceTest.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifferenceTest.class.st
@@ -1,19 +1,19 @@
 Class {
-	#name : 'FamixDiffTest',
+	#name : 'FamixSimpleDifferenceTest',
 	#superclass : 'TestCase',
 	#category : 'Famix-Simple-Diff',
 	#package : 'Famix-Simple-Diff'
 }
 
 { #category : 'tests' }
-FamixDiffTest >> testInstanceCreation [
+FamixSimpleDifferenceTest >> testInstanceCreation [
 	| difference expectedValue actualValue |
 	
 	"testing a code modification"
 	expectedValue := 'private int money;'.
 	actualValue := 'private int age;'.
 	
-	difference := FamixDiff 
+	difference := FamixSimpleDifference 
 						entity: 'testEntity' 
 						changeType: #entityModification
 						expectedValue: expectedValue 


### PR DESCRIPTION
I added a class named "FamixSimpleDifferenceNullValue". This class is following the Null pattern. 
Thanks to this class, we are not using nil anymore in the addition and deletion differences.
I fixed test to match with this new logic.

Closes #20 
