### PR TITLE
Simplify entity comparison using meta description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - main
       - differences-list
       - differences-list-with-meta-model
-      - spliting_auto_and_manual_models_for_tests
+      - simplify_entity_comparison_using_meta_description
 
   pull_request:
     branches:

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -32,9 +32,9 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 			^ self fail ].
 
 	"Comparing properties using Moose meta models" 
-	"We focus on entity with a primitive type (Boolean, Number, String), and we exclude derived propeties to not have differences repetitions" 
+	"We focus on entity with a primitive type (Boolean, Number, String). We exclude derived properties and the numberOfLinesOfCode to not pollute difference list" 
 	properties := aFamixEntity mooseDescription allProperties select: [ :property | 
-			property type isPrimitive and: [property isDerived not] ].
+			property type isPrimitive and: [property isDerived not and:[ property name ~= 'numberOfLinesOfCode' ] ] ].
 
 	"we read property values, and create a difference if they are not equals"
 	properties do: [ :p |

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -31,7 +31,7 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 			self addDifference: diff.
 			^ self fail ].
 
-	"Comparing properties (slots with non-famix values)"
+	"Comparing properties (slots with non-famix values)" 
 	properties := aFamixEntity class allSlots select: [ :slot |
 		              slot class = FMProperty ].
 

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -84,17 +84,17 @@ FamixSimpleDiff >> compareModel: aFamixJavaModel to: aFamixJavaModel2 [
 ]
 
 { #category : 'comparing' }
-FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: otherFamixEntity [
+FamixSimpleDiff >> compareRelation: aRelationDescription from: aFamixEntity to: otherFamixEntity [
 
 	| val1 val2 sortBlock |
-	aFMRelationSlot isToOne
-		ifTrue: [
-				val1 := aFMRelationSlot read: aFamixEntity.
-				val2 := aFMRelationSlot read: otherFamixEntity ]
-		ifFalse: [
+	aRelationDescription isMultivalued
+		ifFalse: ["toOne relation"
+				val1 := aRelationDescription getRawFrom: aFamixEntity.
+				val2 := aRelationDescription getRawFrom: otherFamixEntity ]
+		ifTrue: ["toMany relation"
 				| rejectBlock |
-				val1 := (aFMRelationSlot read: aFamixEntity) asOrderedCollection.
-				val2 := (aFMRelationSlot read: otherFamixEntity) asOrderedCollection.
+				val1 := (aRelationDescription getRawFrom: aFamixEntity) asOrderedCollection.
+				val2 := (aRelationDescription getRawFrom: otherFamixEntity) asOrderedCollection.
 
 				sortBlock := val1
 					             ifEmpty: [ self sortBlock ]
@@ -112,13 +112,13 @@ FamixSimpleDiff >> compareRelation: aFMRelationSlot from: aFamixEntity to: other
 	This guards for that..."
 	val1 == val2 ifTrue: [ ^ true ].
 
-	^ aFMRelationSlot isToOne
-		  ifTrue: [
+	^ aRelationDescription isMultivalued
+		  ifFalse: [
 			  self
 				  compareToOneRelation: val1
 				  actual: val2
 				  target: otherFamixEntity ]
-		  ifFalse: [
+		  ifTrue: [
 			  self
 				  compareToManyRelation: val1
 				  actual: val2

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -32,9 +32,9 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 			^ self fail ].
 
 	"Comparing properties using Moose meta models" 
-	"We focus on entity with a primitive type (Boolean, Number, String). Object type represent relations"
+	"We focus on entity with a primitive type (Boolean, Number, String), and we exclude derived propeties to not have differences repetitions" 
 	properties := aFamixEntity mooseDescription allProperties select: [ :property | 
-			property type isPrimitive].
+			property type isPrimitive and: [property isDerived not] ].
 
 	"we read property values, and create a difference if they are not equals"
 	properties do: [ :p |

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -36,18 +36,18 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 	properties := aFamixEntity mooseDescription allProperties select: [ :property | 
 			property type isPrimitive].
 
+	"we read property values, and create a difference if they are not equals"
 	properties do: [ :p |
-			(p read: aFamixEntity) = (p read: otherFamixEntity) ifFalse: [
-					| prop1 prop2 |
-					prop1 := p read: aFamixEntity.
-					prop2 := p read: otherFamixEntity.
-
-					diff := FamixSimpleDifference
-						        createPropertyChanged: otherFamixEntity
-						        expectedValue: prop1
-						        actualValue: prop2.
-					self addDifference: diff.
-					isEquals := false ] ].
+		| property1 property2 |
+		property1 := p getRawFrom: aFamixEntity.
+		property2 := p getRawFrom: otherFamixEntity.
+		property1 = property2 ifFalse: [
+				diff := FamixSimpleDifference
+					        createPropertyChanged: otherFamixEntity
+					        expectedValue: property1
+					        actualValue: property2.
+				self addDifference: diff.
+				isEquals := false ] ].
 
 	"Comparing relations (slots with famix values)"
 	"We exclude source anchors because they are not relevant to model comparison"

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -55,8 +55,7 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 	"We focus on non primitive property (objects), and we exclude source anchors and derived property because they are not relevant to model comparison"
 	relations := aFamixEntity mooseDescription allProperties select: [ :property |
 			             property type isPrimitive not and: [
-				             property isDerived not and: [
-					             property name ~= 'sourceAnchor' ] ] ].
+				          	property name ~= 'sourceAnchor' ] ].
 
 	relations do: [ :r |
 			(self compareRelation: r from: aFamixEntity to: otherFamixEntity)

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -33,8 +33,10 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 
 	"Comparing properties using Moose meta models" 
 	"We focus on entity with a primitive type (Boolean, Number, String). We exclude derived properties and the numberOfLinesOfCode to not pollute difference list" 
-	properties := aFamixEntity mooseDescription allProperties select: [ :property | 
-			property type isPrimitive and: [property isDerived not and:[ property name ~= 'numberOfLinesOfCode' ] ] ].
+	properties := aFamixEntity mooseDescription allProperties select: [ :property |
+			              property type isPrimitive and: [
+				              property isDerived not and: [
+					              property name ~= 'numberOfLinesOfCode' ] ] ].
 
 	"we read property values, and create a difference if they are not equals"
 	properties do: [ :p |

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -31,9 +31,10 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 			self addDifference: diff.
 			^ self fail ].
 
-	"Comparing properties (slots with non-famix values)" 
-	properties := aFamixEntity class allSlots select: [ :slot |
-		              slot class = FMProperty ].
+	"Comparing properties using Moose meta models" 
+	"We focus on entity with a primitive type (Boolean, Number, String). Object type represent relations"
+	properties := aFamixEntity mooseDescription allProperties select: [ :property | 
+			property type isPrimitive].
 
 	properties do: [ :p |
 			(p read: aFamixEntity) = (p read: otherFamixEntity) ifFalse: [

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -51,11 +51,12 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 				self addDifference: diff.
 				isEquals := false ] ].
 
-	"Comparing relations (slots with famix values)"
-	"We exclude source anchors because they are not relevant to model comparison"
-	relations := aFamixEntity class allSlots select: [ :slot |
-		             slot isFMRelationSlot and: [
-			             slot name ~= 'sourceAnchor' ] ].
+	"Comparing relations using Moose meta models"
+	"We focus on non primitive property (objects), and we exclude source anchors and derived property because they are not relevant to model comparison"
+	relations := aFamixEntity mooseDescription allProperties select: [ :property |
+			             property type isPrimitive not and: [
+				             property isDerived not and: [
+					             property name ~= 'sourceAnchor' ] ] ].
 
 	relations do: [ :r |
 			(self compareRelation: r from: aFamixEntity to: otherFamixEntity)


### PR DESCRIPTION
I changed the logic of Famix Simple Diff, and we are now using meta models and Moose description instead of slots.
Here are the things that I changed: 
1) Property selection
```Smalltalk
properties := aFamixEntity class allSlots select: [ :slot |
		              slot class = FMProperty ].
```
is now like this 
```Smalltalk
	properties := aFamixEntity mooseDescription allProperties select: [ :property |
			              property type isPrimitive and: [
				              property isDerived not and: [
					              property name ~= 'numberOfLinesOfCode' ] ] ].
```
we use Moose description with the method allProperties to get all the properties of the models.
We want the primitive types(Number,Boolean,String). They represent all the properties of the models.
We exclude the derived properties to not have the same differences multiple times.
We also exclude numberOfLinesOfCode which is useless for the comparison.

As we dont have slots anymore, we can't use **read** to use them. So now we are using **getRawFrom**, which is the equivalent for Moose meta models.

2) Relation selection
I changed this code:
```Smalltalk
relations := aFamixEntity class allSlots select: [ :slot |
		             slot isFMRelationSlot and: [
			             slot name ~= 'sourceAnchor' ] ].
```
to this code 

```Smalltalk
relations := aFamixEntity mooseDescription allProperties select: [ :property |
			             property type isPrimitive not and: [
				          	property name ~= 'sourceAnchor' ] ].
```
This is the same logic. We get all the properties of the models that are not primitives one (objects, so relations).  To do so, I changed the method compareRelation:from:to: in order to use **getRawFrom:** instead of **read**.

3) isMultivalued 

We are now using **isMultivalued** to know is relations are toOne or toMany.

All tests are OK with this new logic.

Closes issue #4 