### PR TITLE
Updating difference objects

### DIFF
--- a/Famix-Simple-Diff-Tests/FamixSimpleDifferenceTest.class.st
+++ b/Famix-Simple-Diff-Tests/FamixSimpleDifferenceTest.class.st
@@ -35,7 +35,7 @@ FamixSimpleDifferenceTest >> testChangeTypeNameEntityDeletion [
 { #category : 'tests' }
 FamixSimpleDifferenceTest >> testChangeTypeNamePropertyChanged [
 	| propertyChanged |
-	propertyChanged := FamixSimpleDifference createPropertyChanged: 'Entity' expectedValue: 'Expected' actualValue: 'Actual'.
+	propertyChanged := FamixSimpleDifference createPropertyChanged: '#name' entity: 'Entity' expectedValue: 'Expected' actualValue: 'Actual'.
 	
 	self assert: propertyChanged changeTypeName equals: 'Property Changed'.
 ]

--- a/Famix-Simple-Diff-Tests/FamixSimpleDifferenceTest.class.st
+++ b/Famix-Simple-Diff-Tests/FamixSimpleDifferenceTest.class.st
@@ -34,18 +34,32 @@ FamixSimpleDifferenceTest >> testChangeTypeNameEntityDeletion [
 
 { #category : 'tests' }
 FamixSimpleDifferenceTest >> testChangeTypeNamePropertyChanged [
+
 	| propertyChanged |
-	propertyChanged := FamixSimpleDifference createPropertyChanged: '#name' entity: 'Entity' expectedValue: 'Expected' actualValue: 'Actual'.
-	
-	self assert: propertyChanged changeTypeName equals: 'Property Changed'.
+	propertyChanged := FamixSimpleDifference
+		                   createPropertyChanged: '#name'
+		                   entity: 'Entity'
+		                   expectedValue: 'Expected'
+		                   actualValue: 'Actual'.
+
+	self
+		assert: propertyChanged changeTypeName
+		equals: 'Property Changed'
 ]
 
 { #category : 'tests' }
 FamixSimpleDifferenceTest >> testChangeTypeNameRelationChanged [
+
 	| relationChanged |
-	relationChanged := FamixSimpleDifference createRelationChanged: 'Entity' expectedValue: 'Expected' actualValue: 'Actual'.
-	
-	self assert: relationChanged changeTypeName equals: 'Relation Changed'.
+	relationChanged := FamixSimpleDifference
+		                   createRelationChanged: '#name'
+		                   entity: 'Entity'
+		                   expectedValue: 'Expected'
+		                   actualValue: 'Actual'.
+
+	self
+		assert: relationChanged changeTypeName
+		equals: 'Relation Changed'
 ]
 
 { #category : 'tests' }

--- a/Famix-Simple-Diff-Tests/FamixSimpleDifferenceTest.class.st
+++ b/Famix-Simple-Diff-Tests/FamixSimpleDifferenceTest.class.st
@@ -94,12 +94,30 @@ FamixSimpleDifferenceTest >> testNullValues [
 
 { #category : 'accessing' }
 FamixSimpleDifferenceTest >> testPrintOn [
+
 	| additionDiff output expectedString |
-	
-	additionDiff := FamixSimpleDifference createEntityAdded: 'Entity' actualValue: 'Actual'.
+	additionDiff := FamixSimpleDifference
+		                createEntityAdded: 'Entity'
+		                actualValue: 'Actual'.
 	output := additionDiff printString.
 	expectedString := 'a FamixSimpleDifferenceEntityAddition(''Entity Addition'' -> Expected: Nothing | Actual: ''Actual'' | On: ''Entity'')'.
-	
+
 	"strings should be equals"
-	self assert: output equals: expectedString. 
+	self assert: output equals: expectedString
+]
+
+{ #category : 'accessing' }
+FamixSimpleDifferenceTest >> testPrintOnWithPropertyName [
+
+	| diff output expectedString |
+	diff := FamixSimpleDifference
+		        createPropertyChanged: 'modifiers'
+		        entity: 'Entity'
+		        expectedValue: 'public'
+		        actualValue: 'private'.
+
+	output := diff printString.
+	expectedString := 'a FamixSimpleDifferencePropertyChanged(''Property Changed''| Property Name: modifiers -> Expected: ''public'' | Actual: ''private'' | On: ''Entity'')'.
+
+	self assert: output equals: expectedString
 ]

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -111,18 +111,20 @@ FamixSimpleDiff >> compareRelation: aRelationDescription from: aFamixEntity to: 
 
 	| val1 val2 sortBlock |
 	aRelationDescription isMultivalued
-		ifFalse: ["toOne relation"
+		ifFalse: [ "toOne relation"
 				val1 := aRelationDescription getRawFrom: aFamixEntity.
 				val2 := aRelationDescription getRawFrom: otherFamixEntity ]
-		ifTrue: ["toMany relation"
+		ifTrue: [ "toMany relation"
 				| rejectBlock |
-				val1 := (aRelationDescription getRawFrom: aFamixEntity) asOrderedCollection.
-				val2 := (aRelationDescription getRawFrom: otherFamixEntity) asOrderedCollection.
+				val1 := (aRelationDescription getRawFrom: aFamixEntity)
+					        asOrderedCollection.
+				val2 := (aRelationDescription getRawFrom: otherFamixEntity)
+					        asOrderedCollection.
 
 				rejectBlock := [ :e | e name = 'clone' ].
 				val1 := val1 reject: rejectBlock.
 				val2 := val2 reject: rejectBlock.
-				
+
 				sortBlock := self sort.
 				val1 := val1 sorted: sortBlock.
 				val2 := val2 sorted: sortBlock ].
@@ -133,10 +135,11 @@ FamixSimpleDiff >> compareRelation: aRelationDescription from: aFamixEntity to: 
 
 	^ aRelationDescription isMultivalued
 		  ifFalse: [
-			  self
-				  compareToOneRelation: val1
-				  actual: val2
-				  target: otherFamixEntity ]
+				  self
+					  compareToOneRelation: val1
+					  actual: val2
+					  target: otherFamixEntity
+					  relation: aRelationDescription ]
 		  ifTrue: [
 			  self
 				  compareToManyRelation: val1
@@ -202,14 +205,16 @@ FamixSimpleDiff >> compareToManyRelation: val1 actual: val2 target: anEntity [
 ]
 
 { #category : 'comparing' }
-FamixSimpleDiff >> compareToOneRelation: val1 actual: val2 target: anEntity [
+FamixSimpleDiff >> compareToOneRelation: val1 actual: val2 target: anEntity relation: aRelationDescription [
 
 	| areEquals diff |
 	"if we dont have the same relations, so it changed, we have to record it"
-	areEquals := (self pathesForMaybeMultiRelation: val1) = (self pathesForMaybeMultiRelation: val2).
+	areEquals := (self pathesForMaybeMultiRelation: val1)
+	             = (self pathesForMaybeMultiRelation: val2).
 	areEquals ifFalse: [
 			diff := FamixSimpleDifference
-				        createRelationChanged: anEntity
+				        createRelationChanged: aRelationDescription name
+				        entity: anEntity
 				        expectedValue: val1
 				        actualValue: val2.
 			self addDifference: diff ].

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -68,7 +68,8 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity property: pr
 			property1 = property2
 				ifFalse: [
 						diff := FamixSimpleDifference
-							        createPropertyChanged: otherFamixEntity
+							        createPropertyChanged: property name
+							        entity: otherFamixEntity
 							        expectedValue: property1
 							        actualValue: property2.
 						self addDifference: diff.

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -38,9 +38,13 @@ FamixSimpleDiff >> compareEntity: aFamixEntity to: otherFamixEntity [
 			self addDifference: diff.
 			^ self fail ].
 
-	aFamixEntity mooseDescription allProperties do: [ :prop |
-		isEquals := isEquals & (self compareEntity: aFamixEntity to: otherFamixEntity property: prop)
-	].
+	aFamixEntity metadescription allPropertiesDo: [ :prop |
+			isEquals := isEquals
+			            &
+			            (self
+				             compareEntity: aFamixEntity
+				             to: otherFamixEntity
+				             property: prop) ].
 
 	"we stop the execution here if models are differents"
 	isEquals ifFalse: [ ^ self fail ].

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -62,16 +62,6 @@ FamixSimpleDifference class >> createPropertyChanged: aPropertyName entity: anEn
 ]
 
 { #category : 'instance creation' }
-FamixSimpleDifference class >> createPropertyChanged: anEntity expectedValue: expectedValue actualValue: actualValue [
-
-	^ FamixSimpleDifferencePropertyChanged new
-		  entity: anEntity;
-		  expectedValue: expectedValue;
-		  actualValue: actualValue;
-		  yourself
-]
-
-{ #category : 'instance creation' }
 FamixSimpleDifference class >> createRelationChanged: aRelationName entity: anEntity expectedValue: expectedValue actualValue: actualValue [
 
 	^ FamixSimpleDifferenceRelationChanged new

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -115,6 +115,11 @@ FamixSimpleDifference >> printOn: aStream [
 	aStream nextPutAll: '('.
 	aStream print: self changeTypeName.
 	
+	self propertyName ifNotNil: [ 
+		aStream nextPutAll: 'Property Name: ';
+				  nextPutAll: self propertyName asString
+	].
+	
 	aStream 
 		nextPutAll: ' -> Expected: '; 
 		print: expectedValue;

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -116,7 +116,7 @@ FamixSimpleDifference >> printOn: aStream [
 	aStream print: self changeTypeName.
 	
 	self propertyName ifNotNil: [ 
-		aStream nextPutAll: 'Property Name: ';
+		aStream nextPutAll: '| Property Name: ';
 				  nextPutAll: self propertyName asString
 	].
 	

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -21,30 +21,33 @@ Class {
 }
 
 { #category : 'instance creation' }
-FamixSimpleDifference class >> createEntityAdded: anEntity actualValue: actualValue [ 
+FamixSimpleDifference class >> createEntityAdded: anEntity actualValue: actualValue [
+
 	^ FamixSimpleDifferenceEntityAddition new
-		entity: anEntity;
-		expectedValue: FamixSimpleDifferenceNullValue new;
-		actualValue: actualValue;
-		yourself
+		  entity: anEntity;
+		  expectedValue: FamixSimpleDifferenceNullValue new;
+		  actualValue: actualValue;
+		  yourself
 ]
 
 { #category : 'instance creation' }
-FamixSimpleDifference class >> createEntityChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
+FamixSimpleDifference class >> createEntityChanged: anEntity expectedValue: expectedValue actualValue: actualValue [
+
 	^ FamixSimpleDifferenceEntityChanged new
-		entity: anEntity; 
-		expectedValue: expectedValue;
-		actualValue: actualValue;
-		yourself 
+		  entity: anEntity;
+		  expectedValue: expectedValue;
+		  actualValue: actualValue;
+		  yourself
 ]
 
 { #category : 'instance creation' }
-FamixSimpleDifference class >> createEntityDeletion: anEntity expectedValue: expectedValue [ 
+FamixSimpleDifference class >> createEntityDeletion: anEntity expectedValue: expectedValue [
+
 	^ FamixSimpleDifferenceEntityDeletion new
-		entity: anEntity;
-		expectedValue: expectedValue;
-		actualValue: FamixSimpleDifferenceNullValue new;
-		yourself 
+		  entity: anEntity;
+		  expectedValue: expectedValue;
+		  actualValue: FamixSimpleDifferenceNullValue new;
+		  yourself
 ]
 
 { #category : 'instance creation' }
@@ -59,12 +62,13 @@ FamixSimpleDifference class >> createPropertyChanged: aPropertyName entity: anEn
 ]
 
 { #category : 'instance creation' }
-FamixSimpleDifference class >> createPropertyChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
+FamixSimpleDifference class >> createPropertyChanged: anEntity expectedValue: expectedValue actualValue: actualValue [
+
 	^ FamixSimpleDifferencePropertyChanged new
-		entity: anEntity; 
-		expectedValue: expectedValue;
-		actualValue: actualValue;
-		yourself 
+		  entity: anEntity;
+		  expectedValue: expectedValue;
+		  actualValue: actualValue;
+		  yourself
 ]
 
 { #category : 'instance creation' }
@@ -79,12 +83,13 @@ FamixSimpleDifference class >> createRelationChanged: aRelationName entity: anEn
 ]
 
 { #category : 'instance creation' }
-FamixSimpleDifference class >> createRelationChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
+FamixSimpleDifference class >> createRelationChanged: anEntity expectedValue: expectedValue actualValue: actualValue [
+
 	^ FamixSimpleDifferenceRelationChanged new
-		entity: anEntity;
-		expectedValue: expectedValue;
-		actualValue: actualValue;
-		yourself
+		  entity: anEntity;
+		  expectedValue: expectedValue;
+		  actualValue: actualValue;
+		  yourself
 ]
 
 { #category : 'accessing' }

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -72,16 +72,6 @@ FamixSimpleDifference class >> createRelationChanged: aRelationName entity: anEn
 		  yourself
 ]
 
-{ #category : 'instance creation' }
-FamixSimpleDifference class >> createRelationChanged: anEntity expectedValue: expectedValue actualValue: actualValue [
-
-	^ FamixSimpleDifferenceRelationChanged new
-		  entity: anEntity;
-		  expectedValue: expectedValue;
-		  actualValue: actualValue;
-		  yourself
-]
-
 { #category : 'accessing' }
 FamixSimpleDifference >> actualValue [
 

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -48,12 +48,34 @@ FamixSimpleDifference class >> createEntityDeletion: anEntity expectedValue: exp
 ]
 
 { #category : 'instance creation' }
+FamixSimpleDifference class >> createPropertyChanged: aPropertyName entity: anEntity expectedValue: expectedValue actualValue: actualValue [
+
+	^ FamixSimpleDifferencePropertyChanged new
+		  propertyName: aPropertyName;
+		  entity: anEntity;
+		  expectedValue: expectedValue;
+		  actualValue: actualValue;
+		  yourself
+]
+
+{ #category : 'instance creation' }
 FamixSimpleDifference class >> createPropertyChanged: anEntity expectedValue: expectedValue actualValue: actualValue [ 
 	^ FamixSimpleDifferencePropertyChanged new
 		entity: anEntity; 
 		expectedValue: expectedValue;
 		actualValue: actualValue;
 		yourself 
+]
+
+{ #category : 'instance creation' }
+FamixSimpleDifference class >> createRelationChanged: aRelationName entity: anEntity expectedValue: expectedValue actualValue: actualValue [
+
+	^ FamixSimpleDifferenceRelationChanged new
+		  propertyName: aRelationName;
+		  entity: anEntity;
+		  expectedValue: expectedValue;
+		  actualValue: actualValue;
+		  yourself
 ]
 
 { #category : 'instance creation' }

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -13,7 +13,8 @@ Class {
 	#instVars : [
 		'entity',
 		'expectedValue',
-		'actualValue'
+		'actualValue',
+		'propertyName'
 	],
 	#category : 'Famix-Simple-Diff',
 	#package : 'Famix-Simple-Diff'
@@ -123,4 +124,16 @@ FamixSimpleDifference >> printOn: aStream [
 	aStream nextPutAll: ' | On: '.
 	aStream print: entity.
 	aStream nextPutAll: ')'.
+]
+
+{ #category : 'accessing' }
+FamixSimpleDifference >> propertyName [
+
+	^ propertyName
+]
+
+{ #category : 'accessing' }
+FamixSimpleDifference >> propertyName: anObject [
+
+	^ propertyName := anObject
 ]

--- a/Famix-Simple-Diff/FamixSimpleDifference.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDifference.class.st
@@ -116,7 +116,7 @@ FamixSimpleDifference >> expectedValue: anObject [
 
 { #category : 'printing' }
 FamixSimpleDifference >> printOn: aStream [
-	"Will build a Stream like: FamixDiff(Addition -> Expected: ' ' | Actual: 'private int something' | On Class1)"
+	"Will build a Stream like:a FamixSimpleDifferenceEntityAddition(Entity Addition -> Expected: Nothing | Actual: 'Actual' | On: Entity)"
 	 
 	super printOn: aStream.
 	aStream nextPutAll: '('.


### PR DESCRIPTION
I added an instance variable to track the properties that changed between two models.
Before this fix, Famix Simple Difference only identified the entity where a change occurred.
Now, it also provides the name of the property that changed.