### PR TITLE
Adding a progress bar for the models comparisons

### DIFF
--- a/Famix-Simple-Diff-Tests/FamixSimpleDifManualTest.class.st
+++ b/Famix-Simple-Diff-Tests/FamixSimpleDifManualTest.class.st
@@ -9,15 +9,6 @@ Class {
 	#package : 'Famix-Simple-Diff-Tests'
 }
 
-{ #category : 'running' }
-FamixSimpleDifManualTest >> setUp [
-	super setUp.
-
-	"fix here to limit window's performances problems"
-	self timeLimit: 30 seconds.
-	"Put here a common initialization logic for tests" 
-]
-
 { #category : 'tests' }
 FamixSimpleDifManualTest >> testClearRemainingAdditionWhenMultipleMethodHaveToBeCleaned [
 	| sd class1 class2 model1 model2 diff methodA1 methodA2 methodB methodC |

--- a/Famix-Simple-Diff-Tests/FamixSimpleDiffAutoTest.class.st
+++ b/Famix-Simple-Diff-Tests/FamixSimpleDiffAutoTest.class.st
@@ -28,7 +28,7 @@ FamixSimpleDiffAutoTest >> setUp [
 	super setUp.
 
 	"fix here to limit window's performances problems"
-	self timeLimit: 15 seconds. 
+	self timeLimit: 30 seconds. 
 	"Put here a common initialization logic for tests"
 	mainModel1 := TestJavaModelBuilder loadMainModel.
 	mainModel2 := TestJavaModelBuilder loadMainModel.

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -440,9 +440,12 @@ FamixSimpleDiff >> processTimerDuring: aWorklistBlock [
 				  "update every seconds"
 				  now - update >= 1000 ifTrue: [
 						  update := now.
-						  job title: 'Comparison of models : ' , (now - time // 1000) asString, ' s'.
-						  job currentValue: (((now - time) // 50)\\100). "loop every 5 seconds"
-						  World doOneCycleNow ] ] ] asJob run
+						  job title: 'Comparison of models : ' , (now - time // 1000) asString , ' s'.
+						  job currentValue: ((now - time // 50) \\ 100).
+						
+						  "updating UI"
+						  UIManager default currentWorld ifNotNil: [ :world |
+							  world doOneCycleNow ] ] ] ] asJob run
 ]
 
 { #category : 'comparing' }

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -446,10 +446,19 @@ FamixSimpleDiff >> processTimerDuring: aWorklistBlock [
 { #category : 'comparing' }
 FamixSimpleDiff >> processWorklist: worklist visited: visited [
 	"Process the worklist using a progress bar to show the comparison progress"
-	[ worklist isEmpty ] whileFalse: [
-			(self processNextTaskFrom: worklist visited: visited) ifFalse: [
-				^ self fail ] ].
-	^ differences isEmpty
+
+	| timeCounter |
+	timeCounter := 0.
+
+	"start the timer and process the worklist"
+	^ self processTimerDuring: [ :timerTick |
+			  [ worklist isEmpty ] whileFalse: [
+					  (self processNextTaskFrom: worklist visited: visited) ifFalse: [^ self fail ].
+					  timeCounter := timeCounter + 1.
+
+					  "update tick"
+					  timeCounter \\ 1000 = 0 ifTrue: [ timerTick value ] ].
+			  differences isEmpty ]
 ]
 
 { #category : 'comparing' }

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -73,10 +73,7 @@ FamixSimpleDiff >> compareModel: aFamixModel to: aFamixModel2 [
 	visited := IdentitySet new.
 
 	"doing tasks until the tasklist is empty"
-	[ worklist isEmpty ] whileFalse: [
-			(self processNextTaskFrom: worklist visited: visited) ifFalse: [
-				^ self fail ] ].
-	^ differences isEmpty
+	^ self processWorklist: worklist visited: visited 
 ]
 
 { #category : 'comparing' }
@@ -421,6 +418,38 @@ FamixSimpleDiff >> processNextTaskFrom: worklist visited: visited [
 			"complete worklist"
 			self enqueueRemainingTasksOf: entity1 and: entity2 into: worklist ].
 	^ true
+]
+
+{ #category : 'comparing' }
+FamixSimpleDiff >> processTimerDuring: aWorklistBlock [
+	"Will update the timer of models comparison in a dedicated Job"
+
+	| time update |
+	time := Time millisecondClockValue.
+	update := time.
+
+	^ [ :job |
+		  job title: 'Comparison of models : 0 s'.
+
+		  aWorklistBlock value: [
+				  | now |
+				  now := Time millisecondClockValue.
+
+				  "update every seconds"
+				  now - update >= 1000 ifTrue: [
+						  update := now.
+						  job title:
+							  'Comparison of models : ' , (now - time // 1000) asString , ' s'.
+						  World doOneCycleNow ] ] ] asJob run
+]
+
+{ #category : 'comparing' }
+FamixSimpleDiff >> processWorklist: worklist visited: visited [
+	"Process the worklist using a progress bar to show the comparison progress"
+	[ worklist isEmpty ] whileFalse: [
+			(self processNextTaskFrom: worklist visited: visited) ifFalse: [
+				^ self fail ] ].
+	^ differences isEmpty
 ]
 
 { #category : 'comparing' }

--- a/Famix-Simple-Diff/FamixSimpleDiff.class.st
+++ b/Famix-Simple-Diff/FamixSimpleDiff.class.st
@@ -430,6 +430,8 @@ FamixSimpleDiff >> processTimerDuring: aWorklistBlock [
 
 	^ [ :job |
 		  job title: 'Comparison of models : 0 s'.
+		  job min: 0.
+		  job max: 100.
 
 		  aWorklistBlock value: [
 				  | now |
@@ -438,8 +440,8 @@ FamixSimpleDiff >> processTimerDuring: aWorklistBlock [
 				  "update every seconds"
 				  now - update >= 1000 ifTrue: [
 						  update := now.
-						  job title:
-							  'Comparison of models : ' , (now - time // 1000) asString , ' s'.
+						  job title: 'Comparison of models : ' , (now - time // 1000) asString, ' s'.
+						  job currentValue: (((now - time) // 50)\\100). "loop every 5 seconds"
 						  World doOneCycleNow ] ] ] asJob run
 ]
 


### PR DESCRIPTION
I added a progress bar for the comparison of models.
For some models comparison like the JDK we don't know really know if pharo is freeze or just comparing models.

I also increased the time limit for tests and deleted this time limit for manual tests because this is useless